### PR TITLE
Feature/2 rebranding deep

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ node that it will connect to. This can be done either via `-p` parameter or via 
 
 If you're launching REST gateway in bundle with [frostfs-dev-env](https://github.com/TrueCloudLab/frostfs-dev-env), you can get
 an IP address of the node in output of `make hosts` command
-(with s0*.neofs.devenv name).
+(with s0*.frostfs.devenv name).
 
 These two commands are functionally equivalent, they run the gate with one backend node (and otherwise default
 settings):

--- a/cmd/frostfs-rest-gw/config.go
+++ b/cmd/frostfs-rest-gw/config.go
@@ -292,7 +292,7 @@ func isValidPeerKey(key string) (int, bool) {
 	return num, true
 }
 
-func getNeoFSKey(logger *zap.Logger, cfg *viper.Viper) (*keys.PrivateKey, error) {
+func getFrostFSKey(logger *zap.Logger, cfg *viper.Viper) (*keys.PrivateKey, error) {
 	walletPath := cfg.GetString(cmdWallet)
 	if len(walletPath) == 0 {
 		walletPath = cfg.GetString(cfgWalletPath)
@@ -418,8 +418,8 @@ func serverConfig(v *viper.Viper) *restapi.ServerConfig {
 	}
 }
 
-func newNeofsAPI(ctx context.Context, logger *zap.Logger, v *viper.Viper) (*handlers.API, error) {
-	key, err := getNeoFSKey(logger, v)
+func newFrostfsAPI(ctx context.Context, logger *zap.Logger, v *viper.Viper) (*handlers.API, error) {
+	key, err := getFrostFSKey(logger, v)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/frostfs-rest-gw/integration_test.go
+++ b/cmd/frostfs-rest-gw/integration_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/TrueCloudLab/frostfs-sdk-go/container"
 	"github.com/TrueCloudLab/frostfs-sdk-go/container/acl"
 	cid "github.com/TrueCloudLab/frostfs-sdk-go/container/id"
-	neofsecdsa "github.com/TrueCloudLab/frostfs-sdk-go/crypto/ecdsa"
+	frostfsecdsa "github.com/TrueCloudLab/frostfs-sdk-go/crypto/ecdsa"
 	"github.com/TrueCloudLab/frostfs-sdk-go/eacl"
 	"github.com/TrueCloudLab/frostfs-sdk-go/netmap"
 	"github.com/TrueCloudLab/frostfs-sdk-go/object"
@@ -43,7 +43,7 @@ const (
 	testListenAddress = "localhost:8082"
 	testHost          = "http://" + testListenAddress
 	testContainerNode = "localhost:8080"
-	testLocalNode     = "s01.neofs.devenv:8080"
+	testLocalNode     = "s01.frostfs.devenv:8080"
 	containerName     = "test-container"
 	localVersion      = "local"
 
@@ -160,7 +160,7 @@ func runServer(ctx context.Context, t *testing.T, node string) context.CancelFun
 	v := getDefaultConfig(node)
 	l := newLogger(v)
 
-	neofsAPI, err := newNeofsAPI(cancelCtx, l, v)
+	frostfsAPI, err := newFrostfsAPI(cancelCtx, l, v)
 	require.NoError(t, err)
 
 	swaggerSpec, err := loads.Analyzed(restapi.SwaggerJSON, "")
@@ -169,7 +169,7 @@ func runServer(ctx context.Context, t *testing.T, node string) context.CancelFun
 	api := operations.NewFrostfsRestGwAPI(swaggerSpec)
 	server := restapi.NewServer(api, serverConfig(v))
 
-	server.ConfigureAPI(neofsAPI.Configure)
+	server.ConfigureAPI(frostfsAPI.Configure)
 
 	go func() {
 		err := server.Serve()
@@ -1126,7 +1126,7 @@ func makeAuthTokenRequest(ctx context.Context, t *testing.T, bearers []*models.B
 }
 
 func signToken(t *testing.T, key *keys.PrivateKey, data []byte) *handlers.BearerToken {
-	signer := neofsecdsa.Signer(key.PrivateKey)
+	signer := frostfsecdsa.Signer(key.PrivateKey)
 	sign, err := signer.Sign(data)
 	require.NoError(t, err)
 
@@ -1138,7 +1138,7 @@ func signToken(t *testing.T, key *keys.PrivateKey, data []byte) *handlers.Bearer
 }
 
 func signTokenWalletConnect(t *testing.T, key *keys.PrivateKey, data []byte) *handlers.BearerToken {
-	signer := neofsecdsa.SignerWalletConnect(key.PrivateKey)
+	signer := frostfsecdsa.SignerWalletConnect(key.PrivateKey)
 	signature, err := signer.Sign(data)
 	require.NoError(t, err)
 

--- a/cmd/frostfs-rest-gw/main.go
+++ b/cmd/frostfs-rest-gw/main.go
@@ -18,7 +18,7 @@ func main() {
 	logger := newLogger(v)
 	validateConfig(v, logger)
 
-	neofsAPI, err := newNeofsAPI(ctx, logger, v)
+	frostfsAPI, err := newFrostfsAPI(ctx, logger, v)
 	if err != nil {
 		logger.Fatal("init frostfs", zap.Error(err))
 	}
@@ -29,7 +29,7 @@ func main() {
 	}
 
 	serverCfg := serverConfig(v)
-	serverCfg.SuccessfulStartCallback = neofsAPI.StartCallback
+	serverCfg.SuccessfulStartCallback = frostfsAPI.StartCallback
 
 	api := operations.NewFrostfsRestGwAPI(swaggerSpec)
 	server := restapi.NewServer(api, serverCfg)
@@ -39,8 +39,8 @@ func main() {
 		}
 	}()
 
-	server.ConfigureAPI(neofsAPI.Configure)
-	neofsAPI.RunServices()
+	server.ConfigureAPI(frostfsAPI.Configure)
+	frostfsAPI.RunServices()
 
 	// serve API
 	if err = server.Serve(); err != nil {

--- a/config/config.env
+++ b/config/config.env
@@ -16,11 +16,11 @@ REST_GW_PROMETHEUS_ADDRESS=localhost:8092
 REST_GW_LOGGER_LEVEL=debug
 
 # Nodes configuration.
-# This configuration make gateway use the first node (grpc://s01.neofs.devenv:8080)
-# while it's healthy. Otherwise, gateway use the second node (grpc://s01.neofs.devenv:8080)
+# This configuration make gateway use the first node (grpc://s01.frostfs.devenv:8080)
+# while it's healthy. Otherwise, gateway use the second node (grpc://s01.frostfs.devenv:8080)
 # for 10% of requests and the third node for 90% of requests.
 # Endpoint.
-REST_GW_POOL_PEERS_0_ADDRESS=grpc://s01.neofs.devenv:8080
+REST_GW_POOL_PEERS_0_ADDRESS=grpc://s01.frostfs.devenv:8080
 # Until nodes with the same priority level are healthy
 # nodes with other priority are not used.
 # Еhe lower the value, the higher the priority.
@@ -28,11 +28,11 @@ REST_GW_POOL_PEERS_0_PRIORITY=1
 # Load distribution proportion for nodes with the same priority.
 REST_GW_POOL_PEERS_0_WEIGHT=1
 
-REST_GW_POOL_PEERS_1_ADDRESS=grpc://s02.neofs.devenv:8080
+REST_GW_POOL_PEERS_1_ADDRESS=grpc://s02.frostfs.devenv:8080
 REST_GW_POOL_PEERS_1_PRIORITY=2
 REST_GW_POOL_PEERS_1_WEIGHT=1
 
-REST_GW_POOL_PEERS_2_ADDRESS=grpc://s03.neofs.devenv:8080
+REST_GW_POOL_PEERS_2_ADDRESS=grpc://s03.frostfs.devenv:8080
 REST_GW_POOL_PEERS_2_PRIORITY=2
 REST_GW_POOL_PEERS_3_WEIGHT=9
 

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -28,13 +28,13 @@ pool:
   error-threshold: 100
 
   # Nodes configuration.
-  # This configuration make gateway use the first node (grpc://s01.neofs.devenv:8080)
-  # while it's healthy. Otherwise, gateway use the second node (grpc://s01.neofs.devenv:8080)
+  # This configuration make gateway use the first node (grpc://s01.frostfs.devenv:8080)
+  # while it's healthy. Otherwise, gateway use the second node (grpc://s01.frostfs.devenv:8080)
   # for 10% of requests and the third node for 90% of requests.
   peers:
     0:
       # Endpoint.
-      address: grpc://s01.neofs.devenv:8080
+      address: grpc://s01.frostfs.devenv:8080
       # Until nodes with the same priority level are healthy
       # nodes with other priority are not used.
       # Еhe lower the value, the higher the priority.
@@ -42,11 +42,11 @@ pool:
       # Load distribution proportion for nodes with the same priority.
       weight: 1
     1:
-      address: grpc://s02.neofs.devenv:8080
+      address: grpc://s02.frostfs.devenv:8080
       priority: 2
       weight: 1
     2:
-      address: grpc://s03.neofs.devenv:8080
+      address: grpc://s03.frostfs.devenv:8080
       priority: 2
       weight: 9
 

--- a/handlers/auth.go
+++ b/handlers/auth.go
@@ -11,7 +11,7 @@ import (
 	"github.com/TrueCloudLab/frostfs-rest-gw/gen/models"
 	"github.com/TrueCloudLab/frostfs-rest-gw/gen/restapi/operations"
 	"github.com/TrueCloudLab/frostfs-rest-gw/internal/util"
-	neofsecdsa "github.com/TrueCloudLab/frostfs-sdk-go/crypto/ecdsa"
+	frostfsecdsa "github.com/TrueCloudLab/frostfs-sdk-go/crypto/ecdsa"
 	"github.com/TrueCloudLab/frostfs-sdk-go/pool"
 	"github.com/TrueCloudLab/frostfs-sdk-go/user"
 	"github.com/go-openapi/runtime/middleware"
@@ -167,7 +167,7 @@ func prepareContainerTokens(ctx context.Context, params containerTokenParams, po
 	stoken.SetIat(iat)
 	stoken.SetExp(exp)
 
-	authKey := neofsecdsa.PublicKey(*key)
+	authKey := frostfsecdsa.PublicKey(*key)
 	stoken.SetAuthKey(&authKey)
 
 	var v2token sessionv2.Token

--- a/handlers/balance.go
+++ b/handlers/balance.go
@@ -11,7 +11,7 @@ import (
 	"github.com/go-openapi/runtime/middleware"
 )
 
-// Balance handler that get balance from NeoFS.
+// Balance handler that get balance from FrostFS.
 func (a *API) Balance(params operations.GetBalanceParams) middleware.Responder {
 	var ownerID user.ID
 	if err := ownerID.DecodeString(params.Address); err != nil {
@@ -22,7 +22,7 @@ func (a *API) Balance(params operations.GetBalanceParams) middleware.Responder {
 	var prm pool.PrmBalanceGet
 	prm.SetAccount(ownerID)
 
-	neofsBalance, err := a.pool.Balance(params.HTTPRequest.Context(), prm)
+	frostfsBalance, err := a.pool.Balance(params.HTTPRequest.Context(), prm)
 	if err != nil {
 		resp := a.logAndGetErrorResponse("get balance", err)
 		return operations.NewGetBalanceBadRequest().WithPayload(resp)
@@ -30,8 +30,8 @@ func (a *API) Balance(params operations.GetBalanceParams) middleware.Responder {
 
 	var resp models.Balance
 	resp.Address = util.NewString(params.Address)
-	resp.Value = util.NewString(strconv.FormatInt(neofsBalance.Value(), 10))
-	resp.Precision = util.NewInteger(int64(neofsBalance.Precision()))
+	resp.Value = util.NewString(strconv.FormatInt(frostfsBalance.Value(), 10))
+	resp.Precision = util.NewInteger(int64(frostfsBalance.Precision()))
 
 	return operations.NewGetBalanceOK().
 		WithPayload(&resp).

--- a/handlers/containers.go
+++ b/handlers/containers.go
@@ -35,7 +35,7 @@ const (
 	attributeTimestamp     = "Timestamp"
 )
 
-// PutContainers handler that creates container in NeoFS.
+// PutContainers handler that creates container in FrostFS.
 func (a *API) PutContainers(params operations.PutContainerParams, principal *models.Principal) middleware.Responder {
 	st, err := formSessionTokenFromHeaders(principal, params.XBearerSignature, params.XBearerSignatureKey, sessionv2.ContainerVerbPut)
 	if err != nil {

--- a/handlers/objects.go
+++ b/handlers/objects.go
@@ -28,7 +28,7 @@ const (
 	attributeFilePath = "FilePath"
 )
 
-// PutObjects handler that uploads object to NeoFS.
+// PutObjects handler that uploads object to FrostFS.
 func (a *API) PutObjects(params operations.PutObjectParams, principal *models.Principal) middleware.Responder {
 	errorResponse := operations.NewPutObjectBadRequest()
 	ctx := params.HTTPRequest.Context()
@@ -180,7 +180,7 @@ func (a *API) GetObjectInfo(params operations.GetObjectInfoParams, principal *mo
 		WithAccessControlAllowOrigin("*")
 }
 
-// DeleteObject handler that removes object from NeoFS.
+// DeleteObject handler that removes object from FrostFS.
 func (a *API) DeleteObject(params operations.DeleteObjectParams, principal *models.Principal) middleware.Responder {
 	errorResponse := operations.NewDeleteObjectBadRequest()
 	ctx := params.HTTPRequest.Context()
@@ -211,7 +211,7 @@ func (a *API) DeleteObject(params operations.DeleteObjectParams, principal *mode
 		WithAccessControlAllowOrigin("*")
 }
 
-// SearchObjects handler that removes object from NeoFS.
+// SearchObjects handler that removes object from FrostFS.
 func (a *API) SearchObjects(params operations.SearchObjectsParams, principal *models.Principal) middleware.Responder {
 	errorResponse := operations.NewSearchObjectsBadRequest()
 	ctx := params.HTTPRequest.Context()

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	namespace      = "neofs_rest_gw"
+	namespace      = "frostfs_rest_gw"
 	stateSubsystem = "state"
 	poolSubsystem  = "pool"
 


### PR DESCRIPTION
Related to #2 
Based and blocked by #3 

**Note:** there are left some old mentions:
* related to `__NEOFS__EXPIRATION_EPOCH` because node doesn't support new attribute yet
* using `nspccdev/neofs-aio-testcontainer` since there isn't similar image in `truecloudlab` yet
* links to [neofs-spec](https://github.com/nspcc-dev/neofs-spec) because we have no doc site for this yet

